### PR TITLE
添加 Remio

### DIFF
--- a/src/lib/utils/init-data.ts
+++ b/src/lib/utils/init-data.ts
@@ -330,6 +330,14 @@ const defaultWebsites: WebsiteInput[] = [
     status: 'approved',
   },
   {
+    title: 'Remio',
+    url: 'https://remio.ai/',
+    description: '本地优先的 AI memory 与个人知识库桌面应用，支持多格式解析、本地索引和向量检索。',
+    category_slug: 'ai-tools',
+    thumbnail: 'https://remio.ai/favicon.ico',
+    status: 'approved',
+  },
+  {
     title: 'Descript',
     url: 'https://www.descript.com',
     description: '面向播客和视频创作者的一体化音视频编辑与配音 AI 工具。',


### PR DESCRIPTION
添加 Remio 到 AI 工具初始数据。\n\nRemio 是本地优先的 AI memory 与个人知识库桌面应用，可以解析文件、网页、录音、邮件、消息、图片和笔记，建立本地索引与向量，用于快速检索个人上下文。